### PR TITLE
choose start date automatically, based on end date + period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## current main
+* Choose query start date automatically based on end date and period ([33])
+
+[#33]:https://github.com/GIScience/ohsome-dashboard/pull/33
+
 ## v1.1.5
 * fix: backend-errors-not-displayed [#37]
 * test: exclude mock data files from code duplication analysis on sonarcloud

--- a/src/app/oshdb/query-form/ohsome-api-query-form/ohsome-api-query-form.component.ts
+++ b/src/app/oshdb/query-form/ohsome-api-query-form/ohsome-api-query-form.component.ts
@@ -56,7 +56,7 @@ export class OhsomeApiQueryFormComponent implements OnInit, AfterViewInit {
   constructor(private metadataProvider: OhsomeApiMetadataProviderService) {
     this.minDate = metadataProvider.getOhsomeMetadataResponse()?.extractRegion.temporalExtent.fromTimestamp ?? "";
     this.maxDate = metadataProvider.getOhsomeMetadataResponse()?.extractRegion.temporalExtent.toTimestamp ?? "";
-    this.start = Utils.loadEnv('startDate', this.minDate);
+    this.start = Utils.loadEnv('startDate', '');
     this.end = Utils.loadEnv('endDate', this.maxDate);
     this.period = Utils.loadEnv('period', this.period);
   }

--- a/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.css
+++ b/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.css
@@ -21,3 +21,8 @@ input[name=start],input[name=end]{
 input[name=start]:focus,input[name=end]:focus{
     width: 13em !important;
 }
+
+input[name=start]::placeholder {
+    color: black;
+    opacity: 1;
+}

--- a/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.html
+++ b/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.html
@@ -5,7 +5,7 @@
         <div class="ui calendar" id="start">
             <div class="ui input">
                 <!--<i class="calendar icon"></i>-->
-                <input type="text" name="start" placeholder="Date/Time" [placeholder]="this.options.minDate" autocomplete="off" [disabled]="disabled" (blur)="onStartBlur()" onfocus="this.select();">
+                <input type="text" name="start" placeholder="Date/Time" [placeholder]="this.autoStartDate()" autocomplete="off" [disabled]="disabled" (blur)="onStartBlur()" onfocus="this.select();">
             </div>
         </div>
 

--- a/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.html
+++ b/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.html
@@ -5,7 +5,7 @@
         <div class="ui calendar" id="start">
             <div class="ui input">
                 <!--<i class="calendar icon"></i>-->
-                <input type="text" name="start" placeholder="Date/Time" autocomplete="off" [disabled]="disabled" (blur)="onStartBlur()" onfocus="this.select();">
+                <input type="text" name="start" placeholder="Date/Time" [placeholder]="this.options.minDate" autocomplete="off" [disabled]="disabled" (blur)="onStartBlur()" onfocus="this.select();">
             </div>
         </div>
 

--- a/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.ts
+++ b/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import * as moment from 'moment';
+import Utils from '../../../../utils';
 
 declare let $: any;
 
@@ -239,5 +240,9 @@ export class TimePeriodPickerInputComponent implements ControlValueAccessor, Aft
     }
     const offset = moment(date).utcOffset();
     return moment(date).add(offset, 'm').toISOString().replace(/\.\d+Z/, 'Z');
+  }
+
+  autoStartDate(): string {
+    return Utils.calculateStartDateFromEndAndPeriod(this.end, this.period, this.options.minDate);
   }
 }

--- a/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.ts
+++ b/src/app/oshdb/query-form/time-period-picker-input/time-period-picker-input.component.ts
@@ -142,14 +142,15 @@ export class TimePeriodPickerInputComponent implements ControlValueAccessor, Aft
   onStartBlur() {
     const date = $('#start').calendar('get date');
     if (date == null) {
-      return;
+      this.start = '';
+    } else {
+      const offset = moment(date).utcOffset();
+      const utctime = moment(date).add(offset, 'm').toISOString().replace(/\.\d+Z/, 'Z');
+
+      this.start = utctime;
     }
-    const offset = moment(date).utcOffset();
-    const utctime = moment(date).add(offset, 'm').toISOString().replace(/\.\d+Z/, 'Z');
 
-    this.start = utctime;
-
-    //propagat complete start/end/period String
+    //propagate complete start/end/period String
     this.propagateChange(this.value);
   }
 
@@ -180,6 +181,7 @@ export class TimePeriodPickerInputComponent implements ControlValueAccessor, Aft
   onEndBlur() {
     const date = $('#end').calendar('get date');
     if (date == null) {
+      $('#end').calendar('set date', this.end, true, false);
       return;
     }
     const offset = moment(date).utcOffset();
@@ -187,7 +189,7 @@ export class TimePeriodPickerInputComponent implements ControlValueAccessor, Aft
 
     this.end = utctime;
 
-    //propagat complete start/end/period String
+    //propagate complete start/end/period String
     this.propagateChange(this.value);
   }
 

--- a/src/app/oshdb/result/result.component.ts
+++ b/src/app/oshdb/result/result.component.ts
@@ -213,18 +213,10 @@ export class ResultComponent implements OnInit, AfterViewInit {
     }
 
     // if start time is not specified: choose a "good" start date automatically
-    // such that: start + n*period ~= end
     if (params.time && params.time.startsWith('/')) {
-      const minDate = moment(this.metadataProvider.getOhsomeMetadataResponse()?.extractRegion.temporalExtent.fromTimestamp);
+      const minDate = this.metadataProvider.getOhsomeMetadataResponse()?.extractRegion.temporalExtent.fromTimestamp;
       const timeParts = params.time.split('/');
-      const period = moment.duration(timeParts[2]);
-      const multiplePeriod = moment.duration();
-      do {
-        multiplePeriod.add(period);
-      } while (moment(timeParts[1]).subtract(multiplePeriod) > minDate);
-      multiplePeriod.subtract(period);
-      const autoStartDate = moment(timeParts[1]).subtract(multiplePeriod);
-      params.time = autoStartDate.toISOString() + params.time;
+      params.time = Utils.calculateStartDateFromEndAndPeriod(timeParts[1], timeParts[2], minDate) + params.time;
     }
 
     if (!this.formValues.filter) {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -37,7 +37,7 @@ export const environment = {
   selectedKey : 'historic',
   selectedValue : '',
   selectedTypes : ['node', 'way'],
-  startDate : '2019-03-01',
+  // startDate : '2019-03-01',
   // endDate : '2020-03-01',
   period : 'P1M',
   viewUpdateTime : false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import * as moment from 'moment';
 import {environment} from './environments/environment';
 
 export default class Utils {
@@ -28,5 +29,20 @@ export default class Utils {
     } else {
       return params.get(key) || '';
     }
+  }
+
+  // helper function which calculates a matching start date for a given end date and peridod
+  // such that: start + n*period ~= end
+  static calculateStartDateFromEndAndPeriod(endDate: string, period: string, minDate: string | undefined | null): string {
+    if (!minDate) return '';
+    const min = moment(minDate);
+    const time = moment(endDate);
+    const p = moment.duration(period);
+    const multiplePeriod = moment.duration();
+    do {
+      multiplePeriod.add(p);
+    } while (moment(time).subtract(multiplePeriod) > min);
+    multiplePeriod.subtract(p);
+    return moment(time).subtract(multiplePeriod).toISOString();
   }
 }


### PR DESCRIPTION
Sometimes it can be annoying that the timestamps in a query results are foremost based on the start date: especially for larger periods (e.g. a yearly interval), the difference between the last included timestamp in the query and the latest available OSM data in the database/ohsome-API can be quite large. Typically, it is more desirable to get the most recent available data.

This PR solves this by calculating the start data automatically (if not manually set), based on the given end date and the given period.

* the start date is kept empty by default; only the end date is filled in with the latest available date of the data base (via `metadata` request)
* if the start date is not set manually, it is calculated manually such that `start + n*period ~= end`, see https://github.com/GIScience/ohsome-dashboard/issues/32#issuecomment-1900170684. (Typically it will work out such that the determined start date matches the end date exactly, but there are some edge cases like February 29 on non-leap years, or a 31th of a month with <31 days, which may result in a few days of variance.)