### PR TITLE
feat: support kubernetes gateway api

### DIFF
--- a/kubernetes/ohsome-dashboard/templates/http-route.yaml
+++ b/kubernetes/ohsome-dashboard/templates/http-route.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "ohsome-dashboard.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ohsome-dashboard.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/kubernetes/ohsome-dashboard/values.yaml
+++ b/kubernetes/ohsome-dashboard/values.yaml
@@ -61,6 +61,26 @@ ingress:
     #   hosts:
     #     - chart-example.local
 
+httpRoute:
+  # HTTPRoute enabled.
+  enabled: false
+  # HTTPRoute annotations.
+  annotations: {}
+  # Which Gateways this Route is attached to.
+  parentRefs:
+    - name: gateway
+      sectionName: http
+      # namespace: default
+  # Hostnames matching HTTP header.
+  hostnames:
+    - ohsome-dashboard.local
+  # List of rules and filters applied.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /headers
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
The helm chart currently supports only the kubernetes ingress api. This PR adds support for the more modern kubernetes gateway api. Generation of the gateway api object is behind a feature flag that is by default disabled.